### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/FilePostprints/Journals/temp2/2003_LAAR_preprint.tex
+++ b/FilePostprints/Journals/temp2/2003_LAAR_preprint.tex
@@ -23,7 +23,7 @@
 
 \setlength{\parindent}{0.0cm}
 
-\newcommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}
+\newcommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}
 
 
 \begin{document}

--- a/FilePostprints/Journals/temp2/2004_IJSS_preprint.tex
+++ b/FilePostprints/Journals/temp2/2004_IJSS_preprint.tex
@@ -36,7 +36,7 @@
 \printbibliography
 
 \vspace{3cm}
-DOI: \href{http://dx.doi.org/10.1080/00207720412331313632}{10.1080/00207720412331313632}
+DOI: \href{https://doi.org/10.1080/00207720412331313632}{10.1080/00207720412331313632}
 
 \vspace{1.5cm}
 Url: \url{http://www.tandfonline.com/doi/abs/10.1080/00207720412331313632}

--- a/FilePostprints/Journals/temp2/2004_RENE_preprint.tex
+++ b/FilePostprints/Journals/temp2/2004_RENE_preprint.tex
@@ -35,7 +35,7 @@
 \printbibliography
 
 \vspace{3cm}
-DOI: \href{http://dx.doi.org/10.1016/j.renene.2004.02.009}{10.1016/j.renene.2004.02.009}
+DOI: \href{https://doi.org/10.1016/j.renene.2004.02.009}{10.1016/j.renene.2004.02.009}
 
 \vspace{1.5cm}
 Url: \url{http://www.sciencedirect.com/science/article/pii/S0960148104000886}

--- a/FilePostprints/Journals/temp2/2004_WE_preprint.tex
+++ b/FilePostprints/Journals/temp2/2004_WE_preprint.tex
@@ -23,7 +23,7 @@
 
 \setlength{\parindent}{0.0cm}
 
-\newcommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}
+\newcommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}
 
 
 \begin{document}

--- a/FilePostprints/Journals/temp2/2012_RENE_preprint.tex
+++ b/FilePostprints/Journals/temp2/2012_RENE_preprint.tex
@@ -23,7 +23,7 @@
 
 \setlength{\parindent}{0.0cm}
 
-\newcommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}
+\newcommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}
 
 \begin{document}
 

--- a/FilePostprints/Journals/temp2/2013_IEEETECa_preprint.tex
+++ b/FilePostprints/Journals/temp2/2013_IEEETECa_preprint.tex
@@ -23,7 +23,7 @@
 
 \setlength{\parindent}{0.0cm}
 
-\newcommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}
+\newcommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}
 
 \begin{document}
 

--- a/FilePostprints/Journals/temp2/2014_IEEETCST_preprint - copia.tex
+++ b/FilePostprints/Journals/temp2/2014_IEEETCST_preprint - copia.tex
@@ -23,7 +23,7 @@
 
 \setlength{\parindent}{0.0cm}
 
-\newcommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}
+\newcommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}
 
 \begin{document}
 

--- a/FilePostprints/Journals/temp2/2014_IEEETCST_preprint.tex
+++ b/FilePostprints/Journals/temp2/2014_IEEETCST_preprint.tex
@@ -23,7 +23,7 @@
 
 \setlength{\parindent}{0.0cm}
 
-\newcommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}
+\newcommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}
 
 \begin{document}
 

--- a/FilePostprints/Journals/temp2/2014_IEEETECa_preprint.tex
+++ b/FilePostprints/Journals/temp2/2014_IEEETECa_preprint.tex
@@ -23,7 +23,7 @@
 
 \setlength{\parindent}{0.0cm}
 
-\newcommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}
+\newcommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}
 
 \begin{document}
 

--- a/FilePostprints/Journals/temp2/2014_IEEETECb_preprint.tex
+++ b/FilePostprints/Journals/temp2/2014_IEEETECb_preprint.tex
@@ -23,7 +23,7 @@
 
 \setlength{\parindent}{0.0cm}
 
-\newcommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}
+\newcommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}
 
 \begin{document}
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating static DOI links, as well as code that generates new ones.

Cheers!